### PR TITLE
Fix tile, item, and character highlighting

### DIFF
--- a/src/new_client/clientlib/PlayerData.cpp
+++ b/src/new_client/clientlib/PlayerData.cpp
@@ -11,9 +11,9 @@
 #include "Constants.h"
 #include "InventoryConstants.h"
 #include "Logger.h"
+#include "RaceAndSex.h"
 #include "RankNames.h"
 #include "ResourceLocations.h"
-#include "RaceAndSex.h"
 
 // NOLINTNEXTLINE
 std::map< unsigned short, looks > PlayerData::lookMap_ {};
@@ -37,6 +37,8 @@ PlayerData::PlayerData()
     , shop_()
     , unique1_()
     , unique2_()
+    , playerIsHoldingShift_( false )
+    , playerIsHoldingControl_( false )
 {
   for ( int i = 0; i < MAX_SKILLS; ++i )
   {
@@ -50,6 +52,35 @@ PlayerData::PlayerData()
 int PlayerData::getMode() const
 {
   return clientSidePlayerInfo_.mode;
+}
+
+void PlayerData::update()
+{
+  playerIsHoldingShift_ = sf::Keyboard::isKeyPressed( sf::Keyboard::LShift );
+
+  playerIsHoldingControl_ = sf::Keyboard::isKeyPressed( sf::Keyboard::LControl );
+}
+
+void PlayerData::onUserInput( const sf::Event& )
+{
+}
+
+void PlayerData::finalize()
+{
+}
+
+void PlayerData::draw( sf::RenderTarget&, sf::RenderStates ) const
+{
+}
+
+bool PlayerData::isHoldingShift() const
+{
+  return playerIsHoldingShift_;
+}
+
+bool PlayerData::isHoldingControl() const
+{
+  return playerIsHoldingControl_;
 }
 
 void PlayerData::setPlayerSprite( int spriteId )

--- a/src/new_client/clientlib/PlayerData.h
+++ b/src/new_client/clientlib/PlayerData.h
@@ -6,6 +6,7 @@
 #include <tuple>
 
 #include "ClientTypes.h"
+#include "Component.h"
 #include "Player.h"
 #include "SkillTab.h"
 
@@ -13,11 +14,19 @@
 
 struct skilltab;
 
-class PlayerData
+class PlayerData : public MenAmongGods::Component
 {
 public:
   PlayerData();
   ~PlayerData() = default;
+
+  virtual void update() override;
+
+  virtual void onUserInput( const sf::Event& e ) override;
+
+  virtual void finalize() override;
+
+  void draw( sf::RenderTarget&, sf::RenderStates ) const;
 
   struct LogMessage
   {
@@ -120,13 +129,16 @@ public:
 
   void clear();
 
+  bool isHoldingShift() const;
+  bool isHoldingControl() const;
+
 private:
   // Holds the name, description, and some client-related settings (split apart later)
   pdata                                    playerInfo_; // This is more what initially gets sent to the server
   bool                                     playerDataHasChanged_;
   cplayer                                  clientSidePlayerInfo_; // This is more the truth of what your character is...
   key                                      okey_;
-  std::array< skilltab, MAX_SKILLS >    skillsList_;
+  std::array< skilltab, MAX_SKILLS >       skillsList_;
   look                                     look_;
   std::string                              password_; // TODO: This is super insecure to store it like this long-term
   std::vector< LogMessage >                messages_;
@@ -142,6 +154,9 @@ private:
   int unique2_;
 
   float lookTimer_;
+
+  bool playerIsHoldingShift_;
+  bool playerIsHoldingControl_;
 };
 
 #endif

--- a/src/new_client/interfacelib/MapDisplay.cpp
+++ b/src/new_client/interfacelib/MapDisplay.cpp
@@ -433,15 +433,6 @@ void MapDisplay::update()
         tmp = 0;
       }
 
-      if ( map_.getFlags( m ) & INFRARED )
-      {
-        tmp |= 256;
-      }
-      if ( map_.getFlags( m ) & UWATER )
-      {
-        tmp |= 512;
-      }
-
       // object
       if ( playerData_.areWallsHidden() == 0 || ( map_.getFlags( m ) & ISITEM ) || autohide( x, y ) )
       {
@@ -540,15 +531,7 @@ void MapDisplay::update()
       {
         tmp |= 128;
       }
-      if ( map_.getFlags( m ) & INFRARED )
-      {
-        tmp |= 256;
-      }
-      if ( map_.getFlags( m ) & UWATER )
-      {
-        tmp |= 512;
-      }
-
+      
       if ( map_.getObject2( m ) != 0 )
       {
         bool isSelected = map_.getCharacterId( m ) == playerData_.getSelectedCharacter();

--- a/src/new_client/interfacelib/MapDisplay.cpp
+++ b/src/new_client/interfacelib/MapDisplay.cpp
@@ -97,10 +97,12 @@ MapDisplay::MapDisplay( const sf::Font& font, MenAmongGods::Map& map, PlayerData
 
 void MapDisplay::draw( sf::RenderTarget& target, sf::RenderStates states ) const
 {
-  for ( const auto& tile : spritesToDraw_ )
+  for ( int i = 0; i < spritesToDraw_.size(); ++i )
   {
-    target.draw( tile.sprite, states );
+    target.draw( spritesToDraw_[ i ].sprite, spritesToDraw_[ i ].renderState );
   }
+
+  states.blendMode = sf::BlendAlpha;
 
   for ( const auto& text : textToDraw_ )
   {
@@ -409,11 +411,12 @@ void MapDisplay::update()
 
       // What is the difference between ba_sprite and back? Can I always use ba_sprite?
       // by using ba_sprite instead; we fixed the intermittent "blank" sprite issue
-      copysprite( m, map_.getBackgroundSprite( m ), map_.getLight( m ) | tmp, x * 32, y * 32, xoff, yoff, map_.getLight( m ) );
+      copysprite( m, map_.getBackgroundSprite( m ), map_.getLight( m ) | tmp, x * 32, y * 32, xoff, yoff, map_.getLight( m ),
+                  MapSprite::SpriteType::Tile );
 
       if ( playerData_.getGotoPosition().x == map_.getX( m ) && playerData_.getGotoPosition().y == map_.getY( m ) )
       {
-        copysprite( m, 31, 0, x * 32, y * 32, xoff, yoff, 0 );
+        copysprite( m, 31, 0, x * 32, y * 32, xoff, yoff, 0, MapSprite::SpriteType::Tile );
       }
     }
   }
@@ -483,28 +486,31 @@ void MapDisplay::update()
 
           if ( hightlight == HL_MAP && tileType_ == 1 && tileX_ == x && tileY_ == y )
           {
-            copysprite( m, tmp2, map_.getLight( m ) | tmp, x * 32, y * 32, xoff, yoff, map_.getLight( m ) );
+            copysprite( m, tmp2, map_.getLight( m ) | tmp, x * 32, y * 32, xoff, yoff, map_.getLight( m ), MapSprite::SpriteType::Tile );
           }
           else
           {
-            copysprite( m, tmp2, map_.getLight( m ) | tmp, x * 32, y * 32, xoff, yoff, map_.getLight( m ) );
+            copysprite( m, tmp2, map_.getLight( m ) | tmp, x * 32, y * 32, xoff, yoff, map_.getLight( m ), MapSprite::SpriteType::Tile );
           }
         }
         else
         {
           if ( hightlight == HL_MAP && tileType_ == 1 && tileX_ == x && tileY_ == y )
           {
-            copysprite( m, map_.getObject1( m ), map_.getLight( m ) | tmp, x * 32, y * 32, xoff, yoff, map_.getLight( m ) );
+            copysprite( m, map_.getObject1( m ), map_.getLight( m ) | tmp, x * 32, y * 32, xoff, yoff, map_.getLight( m ),
+                        MapSprite::SpriteType::Object );
           }
           else
           {
-            copysprite( m, map_.getObject1( m ), map_.getLight( m ) | tmp, x * 32, y * 32, xoff, yoff, map_.getLight( m ) );
+            copysprite( m, map_.getObject1( m ), map_.getLight( m ) | tmp, x * 32, y * 32, xoff, yoff, map_.getLight( m ),
+                        MapSprite::SpriteType::Object );
           }
         }
       }
       else if ( map_.getObject1( m ) )
       {
-        copysprite( m, map_.getObject1( m ) + 1, map_.getLight( m ) | tmp, x * 32, y * 32, xoff, yoff, map_.getLight( m ) );
+        copysprite( m, map_.getObject1( m ) + 1, map_.getLight( m ) | tmp, x * 32, y * 32, xoff, yoff, map_.getLight( m ),
+                    MapSprite::SpriteType::Object );
       }
 
       // character
@@ -531,22 +537,24 @@ void MapDisplay::update()
       {
         tmp |= 128;
       }
-      
+
       if ( map_.getObject2( m ) != 0 )
       {
         bool isSelected = map_.getCharacterId( m ) == playerData_.getSelectedCharacter();
         copysprite( m, map_.getObject2( m ), map_.getLight( m ) | tmp, x * 32, y * 32, xoff + map_.getObjectXOffset( m ),
-                    yoff + map_.getObjectYOffset( m ), map_.getLight( m ), isSelected );
+                    yoff + map_.getObjectYOffset( m ), map_.getLight( m ), MapSprite::SpriteType::Character, isSelected );
       }
 
       if ( playerData_.getAttackTarget() != 0 && playerData_.getAttackTarget() == map_.getCharacterId( m ) )
       {
-        copysprite( m, 34, 0, x * 32, y * 32, xoff + map_.getObjectXOffset( m ), yoff + map_.getObjectYOffset( m ), map_.getLight( m ) );
+        copysprite( m, 34, 0, x * 32, y * 32, xoff + map_.getObjectXOffset( m ), yoff + map_.getObjectYOffset( m ), map_.getLight( m ),
+                    MapSprite::SpriteType::Unspecified );
       }
 
       if ( playerData_.getPlayerAction() == DR_GIVE && playerData_.getFirstTarget() == map_.getCharacterCrc( m ) )
       {
-        copysprite( m, 45, 0, x * 32, y * 32, xoff + map_.getObjectXOffset( m ), yoff + map_.getObjectYOffset( m ), map_.getLight( m ) );
+        copysprite( m, 45, 0, x * 32, y * 32, xoff + map_.getObjectXOffset( m ), yoff + map_.getObjectYOffset( m ), map_.getLight( m ),
+                    MapSprite::SpriteType::Unspecified );
       }
 
       if ( ( playerData_.clientShouldShowNames() | playerData_.clientShouldShowPercentHealth() ) && map_.getCharacterId( m ) )
@@ -594,88 +602,92 @@ void MapDisplay::update()
       if ( playerData_.getPlayerAction() == DR_DROP && playerData_.getFirstTarget() == map_.getX( m ) &&
            playerData_.getSecondTarget() == map_.getY( m ) )
       {
-        copysprite( m, 32, 0, x * 32, y * 32, xoff, yoff, 0 );
+        copysprite( m, 32, 0, x * 32, y * 32, xoff, yoff, 0, MapSprite::SpriteType::Unspecified );
       }
       if ( playerData_.getPlayerAction() == DR_PICKUP && playerData_.getFirstTarget() == map_.getX( m ) &&
            playerData_.getSecondTarget() == map_.getY( m ) )
       {
-        copysprite( m, 33, 0, x * 32, y * 32, xoff, yoff, 0 );
+        copysprite( m, 33, 0, x * 32, y * 32, xoff, yoff, 0, MapSprite::SpriteType::Unspecified );
       }
       if ( playerData_.getPlayerAction() == DR_USE && playerData_.getFirstTarget() == map_.getX( m ) &&
            playerData_.getSecondTarget() == map_.getY( m ) )
       {
-        copysprite( m, 45, 0, x * 32, y * 32, xoff, yoff, 0 );
+        copysprite( m, 45, 0, x * 32, y * 32, xoff, yoff, 0, MapSprite::SpriteType::Unspecified );
       }
 
       // effects
       if ( map_.getFlags2( m ) & MF_MOVEBLOCK )
       {
-        copysprite( m, 55, 0, x * 32, y * 32, xoff, yoff, map_.getLight( m ) );
+        copysprite( m, 55, 0, x * 32, y * 32, xoff, yoff, map_.getLight( m ), MapSprite::SpriteType::Unspecified );
       }
       if ( map_.getFlags2( m ) & MF_SIGHTBLOCK )
       {
-        copysprite( m, 84, 0, x * 32, y * 32, xoff, yoff, map_.getLight( m ) );
+        copysprite( m, 84, 0, x * 32, y * 32, xoff, yoff, map_.getLight( m ), MapSprite::SpriteType::Unspecified );
       }
       if ( map_.getFlags2( m ) & MF_INDOORS )
       {
-        copysprite( m, 56, 0, x * 32, y * 32, xoff, yoff, map_.getLight( m ) );
+        copysprite( m, 56, 0, x * 32, y * 32, xoff, yoff, map_.getLight( m ), MapSprite::SpriteType::Unspecified );
       }
       if ( map_.getFlags2( m ) & MF_UWATER )
       {
-        copysprite( m, 75, 0, x * 32, y * 32, xoff, yoff, map_.getLight( m ) );
+        copysprite( m, 75, 0, x * 32, y * 32, xoff, yoff, map_.getLight( m ), MapSprite::SpriteType::Unspecified );
       }
       if ( map_.getFlags2( m ) & MF_NOMONST )
       {
-        copysprite( m, 59, 0, x * 32, y * 32, xoff, yoff, map_.getLight( m ) );
+        copysprite( m, 59, 0, x * 32, y * 32, xoff, yoff, map_.getLight( m ), MapSprite::SpriteType::Unspecified );
       }
       if ( map_.getFlags2( m ) & MF_BANK )
       {
-        copysprite( m, 60, 0, x * 32, y * 32, xoff, yoff, map_.getLight( m ) );
+        copysprite( m, 60, 0, x * 32, y * 32, xoff, yoff, map_.getLight( m ), MapSprite::SpriteType::Unspecified );
       }
       if ( map_.getFlags2( m ) & MF_TAVERN )
       {
-        copysprite( m, 61, 0, x * 32, y * 32, xoff, yoff, map_.getLight( m ) );
+        copysprite( m, 61, 0, x * 32, y * 32, xoff, yoff, map_.getLight( m ), MapSprite::SpriteType::Unspecified );
       }
       if ( map_.getFlags2( m ) & MF_NOMAGIC )
       {
-        copysprite( m, 62, 0, x * 32, y * 32, xoff, yoff, map_.getLight( m ) );
+        copysprite( m, 62, 0, x * 32, y * 32, xoff, yoff, map_.getLight( m ), MapSprite::SpriteType::Unspecified );
       }
       if ( map_.getFlags2( m ) & MF_DEATHTRAP )
       {
-        copysprite( m, 73, 0, x * 32, y * 32, xoff, yoff, map_.getLight( m ) );
+        copysprite( m, 73, 0, x * 32, y * 32, xoff, yoff, map_.getLight( m ), MapSprite::SpriteType::Unspecified );
       }
       if ( map_.getFlags2( m ) & MF_NOLAG )
       {
-        copysprite( m, 57, 0, x * 32, y * 32, xoff, yoff, map_.getLight( m ) );
+        copysprite( m, 57, 0, x * 32, y * 32, xoff, yoff, map_.getLight( m ), MapSprite::SpriteType::Unspecified );
       }
       if ( map_.getFlags2( m ) & MF_ARENA )
       {
-        copysprite( m, 76, 0, x * 32, y * 32, xoff, yoff, map_.getLight( m ) );
+        copysprite( m, 76, 0, x * 32, y * 32, xoff, yoff, map_.getLight( m ), MapSprite::SpriteType::Unspecified );
       }
       if ( map_.getFlags2( m ) & MF_NOEXPIRE )
       {
-        copysprite( m, 82, 0, x * 32, y * 32, xoff, yoff, map_.getLight( m ) );
+        copysprite( m, 82, 0, x * 32, y * 32, xoff, yoff, map_.getLight( m ), MapSprite::SpriteType::Unspecified );
       }
       if ( map_.getFlags2( m ) & 0x80000000 )
       {
-        copysprite( m, 72, 0, x * 32, y * 32, xoff, yoff, map_.getLight( m ) );
+        copysprite( m, 72, 0, x * 32, y * 32, xoff, yoff, map_.getLight( m ), MapSprite::SpriteType::Unspecified );
       }
 
       if ( ( map_.getFlags( m ) & ( INJURED | INJURED1 | INJURED2 ) ) == INJURED )
       {
-        copysprite( m, 1079, 0, x * 32, y * 32, xoff + map_.getObjectXOffset( m ), yoff + map_.getObjectYOffset( m ), map_.getLight( m ) );
+        copysprite( m, 1079, 0, x * 32, y * 32, xoff + map_.getObjectXOffset( m ), yoff + map_.getObjectYOffset( m ), map_.getLight( m ),
+                    MapSprite::SpriteType::Unspecified );
       }
       if ( ( map_.getFlags( m ) & ( INJURED | INJURED1 | INJURED2 ) ) == ( INJURED | INJURED1 ) )
       {
-        copysprite( m, 1080, 0, x * 32, y * 32, xoff + map_.getObjectXOffset( m ), yoff + map_.getObjectYOffset( m ), map_.getLight( m ) );
+        copysprite( m, 1080, 0, x * 32, y * 32, xoff + map_.getObjectXOffset( m ), yoff + map_.getObjectYOffset( m ), map_.getLight( m ),
+                    MapSprite::SpriteType::Unspecified );
       }
       if ( ( map_.getFlags( m ) & ( INJURED | INJURED1 | INJURED2 ) ) == ( INJURED | INJURED2 ) )
       {
-        copysprite( m, 1081, 0, x * 32, y * 32, xoff + map_.getObjectXOffset( m ), yoff + map_.getObjectYOffset( m ), map_.getLight( m ) );
+        copysprite( m, 1081, 0, x * 32, y * 32, xoff + map_.getObjectXOffset( m ), yoff + map_.getObjectYOffset( m ), map_.getLight( m ),
+                    MapSprite::SpriteType::Unspecified );
       }
       if ( ( map_.getFlags( m ) & ( INJURED | INJURED1 | INJURED2 ) ) == ( INJURED | INJURED1 | INJURED2 ) )
       {
-        copysprite( m, 1082, 0, x * 32, y * 32, xoff + map_.getObjectXOffset( m ), yoff + map_.getObjectYOffset( m ), map_.getLight( m ) );
+        copysprite( m, 1082, 0, x * 32, y * 32, xoff + map_.getObjectXOffset( m ), yoff + map_.getObjectYOffset( m ), map_.getLight( m ),
+                    MapSprite::SpriteType::Unspecified );
       }
 
       if ( map_.getFlags( m ) & DEATH )
@@ -683,17 +695,18 @@ void MapDisplay::update()
         if ( map_.getObject2( m ) )
         {
           copysprite( m, 280 + ( ( map_.getFlags( m ) & DEATH ) >> 17 ) - 1, 0, x * 32, y * 32, xoff + map_.getObjectXOffset( m ),
-                      yoff + map_.getObjectYOffset( m ), map_.getLight( m ) );
+                      yoff + map_.getObjectYOffset( m ), map_.getLight( m ), MapSprite::SpriteType::Unspecified );
         }
         else
         {
-          copysprite( m, 280 + ( ( map_.getFlags( m ) & DEATH ) >> 17 ) - 1, 0, x * 32, y * 32, xoff, yoff, map_.getLight( m ) );
+          copysprite( m, 280 + ( ( map_.getFlags( m ) & DEATH ) >> 17 ) - 1, 0, x * 32, y * 32, xoff, yoff, map_.getLight( m ),
+                      MapSprite::SpriteType::Unspecified );
         }
       }
       if ( map_.getFlags( m ) & TOMB )
       {
         copysprite( m, 240 + ( ( map_.getFlags( m ) & TOMB ) >> 12 ) - 1, map_.getLight( m ), x * 32, y * 32, xoff, yoff,
-                    map_.getLight( m ) );
+                    map_.getLight( m ), MapSprite::SpriteType::Unspecified );
       }
 
       alpha    = 0;
@@ -736,15 +749,55 @@ void MapDisplay::update()
 
   int mapIndex = getMapIndexFromMousePosition( mousePosition );
 
-  auto hoveredSprite = std::find_if( std::begin( spritesToDraw_ ), std::end( spritesToDraw_ ),
-                                     [ & ]( const MapSprite& mapSprite )
-                                     {
-                                       return mapIndex == mapSprite.index;
-                                     } );
-
-  if ( hoveredSprite != std::end( spritesToDraw_ ) )
+  // Add highlights at the end of the render loop to ensure they're always drawn last.  Effectively
+  // what we're doing is copying the SAME sprite, putting in the SAME location, except changing to an additive blend
+  // mode to get the highlight effect that we are looking for.  We use an if/else if chain to ensure
+  // that we're only highlighting one thing at a time to mimic what is done when we issue commands to the server.
+  if ( playerData_.isHoldingControl() )
   {
-    hoveredSprite->sprite.setColor( sf::Color { 128, 128, 128, 255 } );
+    auto hoveredSprite = std::find_if( std::begin( spritesToDraw_ ), std::end( spritesToDraw_ ),
+                                       [ & ]( const MapSprite& mapSprite )
+                                       {
+                                         return mapIndex == mapSprite.index && mapSprite.type == MapSprite::SpriteType::Character;
+                                       } );
+
+    if ( hoveredSprite != std::end( spritesToDraw_ ) )
+    {
+      MapSprite newSprite             = *hoveredSprite;
+      newSprite.renderState.blendMode = sf::BlendAdd;
+      spritesToDraw_.push_back( newSprite );
+    }
+  }
+  else if ( playerData_.isHoldingShift() )
+  {
+    auto hoveredSprite = std::find_if( std::begin( spritesToDraw_ ), std::end( spritesToDraw_ ),
+                                       [ & ]( const MapSprite& mapSprite )
+                                       {
+                                         return mapIndex == mapSprite.index && mapSprite.type == MapSprite::SpriteType::Object;
+                                       } );
+            
+    // For interactable objects, we also need to check to ensure that the item is interactable
+    if ( hoveredSprite != std::end( spritesToDraw_ ) && map_.getFlags( mapIndex ) & ISITEM || map_.getFlags( mapIndex ) & ISUSABLE )
+    {
+      MapSprite newSprite             = *hoveredSprite;
+      newSprite.renderState.blendMode = sf::BlendAdd;
+      spritesToDraw_.push_back( newSprite );
+    }
+  }
+  else
+  {
+    auto hoveredSprite = std::find_if( std::begin( spritesToDraw_ ), std::end( spritesToDraw_ ),
+                                       [ & ]( const MapSprite& mapSprite )
+                                       {
+                                         return mapIndex == mapSprite.index && mapSprite.type == MapSprite::SpriteType::Tile;
+                                       } );
+
+    if ( hoveredSprite != std::end( spritesToDraw_ ) )
+    {
+      MapSprite newSprite             = *hoveredSprite;
+      newSprite.renderState.blendMode = sf::BlendAdd;
+      spritesToDraw_.push_back( newSprite );
+    }
   }
 }
 
@@ -755,7 +808,7 @@ void MapDisplay::copyEffectSprite( int index, int nr, int xpos, int ypos, int xo
     return;
   }
 
-  MapSprite newMapSprite { cache_.getSprite( nr ), index };
+  MapSprite newMapSprite { cache_.getSprite( nr ), index, MapSprite::SpriteType::Unspecified };
   spritesToDraw_.push_back( newMapSprite );
   sf::Sprite& newSprite = ( spritesToDraw_.end() - 1 )->sprite;
 
@@ -802,14 +855,14 @@ void MapDisplay::copyEffectSprite( int index, int nr, int xpos, int ypos, int xo
 }
 
 void MapDisplay::copysprite( int index, int nr, int effect, int xpos, int ypos, int xoff, int yoff, unsigned char light,
-                             bool isCharacterSelected )
+                             MapSprite::SpriteType spriteType, bool isCharacterSelected )
 {
   if ( nr == 0 )
   {
     return;
   }
 
-  MapSprite newMapSprite { cache_.getSprite( nr ), index };
+  MapSprite newMapSprite { cache_.getSprite( nr ), index, spriteType };
   spritesToDraw_.push_back( newMapSprite );
   sf::Sprite& newSprite = ( spritesToDraw_.end() - 1 )->sprite;
 

--- a/src/new_client/interfacelib/MapDisplay.cpp
+++ b/src/new_client/interfacelib/MapDisplay.cpp
@@ -97,7 +97,7 @@ MapDisplay::MapDisplay( const sf::Font& font, MenAmongGods::Map& map, PlayerData
 
 void MapDisplay::draw( sf::RenderTarget& target, sf::RenderStates states ) const
 {
-  for ( int i = 0; i < spritesToDraw_.size(); ++i )
+  for ( int i = 0; i < static_cast< int >( spritesToDraw_.size() ); ++i )
   {
     target.draw( spritesToDraw_[ i ].sprite, spritesToDraw_[ i ].renderState );
   }
@@ -775,9 +775,10 @@ void MapDisplay::update()
                                        {
                                          return mapIndex == mapSprite.index && mapSprite.type == MapSprite::SpriteType::Object;
                                        } );
-            
+
     // For interactable objects, we also need to check to ensure that the item is interactable
-    if ( hoveredSprite != std::end( spritesToDraw_ ) && map_.getFlags( mapIndex ) & ISITEM || map_.getFlags( mapIndex ) & ISUSABLE )
+    if ( hoveredSprite != std::end( spritesToDraw_ ) &&
+         ( ( map_.getFlags( mapIndex ) & ISITEM ) || ( map_.getFlags( mapIndex ) & ISUSABLE ) ) )
     {
       MapSprite newSprite             = *hoveredSprite;
       newSprite.renderState.blendMode = sf::BlendAdd;

--- a/src/new_client/interfacelib/MapDisplay.h
+++ b/src/new_client/interfacelib/MapDisplay.h
@@ -32,19 +32,32 @@ public:
 
   struct MapSprite
   {
-    sf::Sprite sprite;
-    int        index;
+    enum struct SpriteType
+    {
+      Tile,
+      Character,
+      Object,
+      Unspecified
+    };
 
-    MapSprite( sf::Sprite sprite_, int index_ )
+    sf::Sprite       sprite;
+    int              index;
+    SpriteType       type;
+    sf::RenderStates renderState;
+
+    MapSprite( sf::Sprite sprite_, int index_, SpriteType type_ )
         : sprite( sprite_ )
         , index( index_ )
+        , type( type_ )
+        , renderState( sf::BlendAlpha )
     {
     }
   };
 
 private:
-  void copysprite( int index, int nr, int effect, int xpos, int ypos, int xoff, int yoff, unsigned char light, bool isCharacterSelected = false );
-  void copyEffectSprite( int index, int nr, int xpos, int ypos, int xoff, int yoff, sf::Color effectColor );
+  void         copysprite( int index, int nr, int effect, int xpos, int ypos, int xoff, int yoff, unsigned char light,
+                           MapSprite::SpriteType spriteType, bool isCharacterSelected = false );
+  void         copyEffectSprite( int index, int nr, int xpos, int ypos, int xoff, int yoff, sf::Color effectColor );
   sf::Vector2i dd_gputtext( int xpos, int ypos, std::string text, int xoff, int yoff );
 
   const sf::Font&                   font_;

--- a/src/new_client/interfacelib/MapDisplay.h
+++ b/src/new_client/interfacelib/MapDisplay.h
@@ -30,9 +30,6 @@ public:
   // sf::Drawable interface
   virtual void draw( sf::RenderTarget& target, sf::RenderStates states ) const override;
 
-  void loadFromFile( std::string filePath );
-  void saveToFile() const;
-
   struct MapSprite
   {
     sf::Sprite sprite;

--- a/src/new_client/main.cpp
+++ b/src/new_client/main.cpp
@@ -34,7 +34,7 @@ int main( int argc, char** args )
   LOG_SET_LEVEL( MenAmongGods::ClientConfiguration::instance().loggingEnabled() );
 
   auto map        = std::make_unique< MenAmongGods::Map >();
-  auto playerData = std::make_unique< PlayerData >();
+  auto playerData = std::make_shared< PlayerData >();
 
   if ( argc >= 3 )
   {
@@ -82,6 +82,7 @@ int main( int argc, char** args )
   // Populate components
   std::vector< std::shared_ptr< MenAmongGods::Component > > components {};
   components.push_back( mainUiPtr );
+  components.push_back( playerData );
     
   std::vector< std::shared_ptr< MenAmongGods::ClientCommand > > commandList {};
 


### PR DESCRIPTION
Now the character, item, and map sprites should be appropriately highlighted when the user presses the appropriate button (CTRL, SHIFT, etc).